### PR TITLE
Fix calendar styling

### DIFF
--- a/src/Resources/assets/styles/_tailwind.scss
+++ b/src/Resources/assets/styles/_tailwind.scss
@@ -297,7 +297,6 @@ input[type="date"] {
 
     .fc-scrollgrid colgroup > col {
         @apply bg-neutral-200;
-        width: 90px !important;
     }
 
     .fc-timegrid-slot,
@@ -306,10 +305,18 @@ input[type="date"] {
         max-width: 90px;
     }
 
-    // eventColor attribute in fullCalendar settings or eventBackgroundColor custom property would be recommended
-    // But sadly it's not working, so we force it here with the Tailwind color palette
     .fc-event {
-        @apply bg-primary-500 border-primary-500 #{!important};
+        padding: 2px 7px;
+
+        &.fc-event-start {
+            border-top-left-radius: 15px;
+            border-bottom-left-radius: 15px;
+        }
+
+        &.fc-event-end {
+            border-top-right-radius: 15px;
+            border-bottom-right-radius: 15px;
+        }
     }
 }
 


### PR DESCRIPTION
`.fc-scrollgrid` styling breaks resource view and remove !important styling which seems to not be needed anymore