### PR TITLE
feat: enable attributes on modal action

### DIFF
--- a/src/Resources/views/includes/_action.html.twig
+++ b/src/Resources/views/includes/_action.html.twig
@@ -154,10 +154,13 @@
 
 {% block modal_action %}
     {# @var action \araise\CrudBundle\Action\Action #}
+    {% set attr = {
+        type: 'button',
+    }|merge(action.option('attr')|default([]))|filter((k,i) => k != 'class') %}
     <span {{ stimulus_controller('araise/core-bundle/modal-form', { formUrl: path(action.option('route'), action.option('route_parameters')) }) }}>
         <button
-            type="button"
-            class="whatwedo-crud-button--action group flex items-center px-4 py-2 ml-0"
+            class="whatwedo-crud-button--action group flex items-center px-4 py-2 ml-0 {{ action.option('attr')['class'] ?? '' }}"
+            {{ attr|map((value, attr) => "#{attr}=\"#{value}\"")|join(' ')|raw }}
             {{ stimulus_action('araise/core-bundle/modal-form', 'openModal') }}
         >
             {% if action.option('icon') %}


### PR DESCRIPTION
Uses the defined attributes and renders them on the button, even if the block_prefix is set to `modal_action`:

```php
$this->addAction('test', [
    'label' => 'test',
    'visibility' => [Page::SHOW],
    'route' => static::getRoute(Page::SHOW),
    'route_parameters' => [
        'id' => $data->getId(),
    ],
    Action::OPT_BLOCK_PREFIX => 'modal_action',
    Action::OPT_ATTR => [
         'data-test' => 'test',
    ]
]);
```