### PR TITLE
Combobox Controller

### DIFF
--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -41,8 +41,8 @@ class ChoiceTypeExtension extends AbstractTypeExtension
      */
     public function finishView(FormView $view, FormInterface $form, array $options): void
     {
-        $view->vars['attr']['data-controller'] = 'araise--core-bundle--select';
-        $view->vars['attr']['data-araise--core-bundle--select-required-value'] = $options['required'];
+        $view->vars['attr']['data-controller'] = 'araise--core-bundle--combobox';
+        $view->vars['attr']['data-araise--combobox-bundle--select-required-value'] = $options['required'];
     }
 
     public static function getExtendedTypes(): iterable

--- a/src/Resources/assets/controllers/combobox_controller.js
+++ b/src/Resources/assets/controllers/combobox_controller.js
@@ -2,12 +2,11 @@ import { Controller } from '@hotwired/stimulus';
 import TomSelect from 'tom-select';
 import 'tom-select/dist/css/tom-select.css';
 
-
 export default class extends Controller {
     static values = {
         url: String,
-        required: Boolean,
-        min: 2
+        min: 2,
+        options: Object,
     }
 
     _url = null;
@@ -33,18 +32,13 @@ export default class extends Controller {
         if (this.element.tagName !== 'SELECT') {
             return;
         }
-        const settings = {
-            maxOptions: 50
-        };
+        const settings = {};
 
         settings.onItemAdd = (value) => {
             this.tomSelect.setTextboxValue('');
             this.tomSelect.refreshOptions();
         };
 
-        if (this.requiredValue === false) {
-            settings.allowEmptyOption = true;
-        }
         if (this._url !== '') {
             settings.sortField = {
                 field: "text",
@@ -70,6 +64,6 @@ export default class extends Controller {
                 return query.length >= that._min;
             }
         }
-        this.tomSelect = new TomSelect(this.element, settings);
+        this.tomSelect = new TomSelect(this.element, {...settings, ...this.optionsValue});
     }
 }

--- a/src/Resources/assets/controllers/combobox_controller.js
+++ b/src/Resources/assets/controllers/combobox_controller.js
@@ -5,7 +5,10 @@ import 'tom-select/dist/css/tom-select.css';
 export default class extends Controller {
     static values = {
         url: String,
-        min: 2,
+        min: {
+            type: Number,
+            default: 2
+        },
         options: Object,
     }
 

--- a/src/Resources/assets/controllers/select_controller.js
+++ b/src/Resources/assets/controllers/select_controller.js
@@ -36,6 +36,12 @@ export default class extends Controller {
         const settings = {
             maxOptions: 50
         };
+
+        settings.onItemAdd = (value) => {
+            this.tomSelect.setTextboxValue('');
+            this.tomSelect.refreshOptions();
+        };
+
         if (this.requiredValue === false) {
             settings.allowEmptyOption = true;
         }

--- a/src/Resources/assets/package.json
+++ b/src/Resources/assets/package.json
@@ -3,8 +3,8 @@
     "version": "1.0.0",
     "symfony": {
         "controllers": {
-            "select": {
-                "main": "controllers/select_controller.js",
+            "combobox": {
+                "main": "controllers/combobox_controller.js",
                 "webpackMode": "eager",
                 "fetch": "eager",
                 "enabled": true


### PR DESCRIPTION
As described in this ticket:
https://dev.whatwedo.ch/araise/araise-meta/-/issues/42

I renamed and replaced the controller from "select" to "combobox" and since we do have a rename we have a breaking change. So I skipped a setting without deprecation.

All options can be added via an object to keep it simple and as flexible as possible.