### PR TITLE
Feature/twig stringify filter

### DIFF
--- a/src/Twig/StringConverterExtension.php
+++ b/src/Twig/StringConverterExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace araise\CoreBundle\Twig;
+
+use araise\CoreBundle\Util\StringConverter;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class StringConverterExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('araise_core_stringify', [StringConverter::class, 'toString']),
+        ];
+    }
+}

--- a/src/Util/StringConverter.php
+++ b/src/Util/StringConverter.php
@@ -21,6 +21,10 @@ class StringConverter
 
     private static function objectToString(object $value): string
     {
+        if ($value instanceof \BackedEnum) {
+            return $value->value;
+        }
+
         if (method_exists($value, '__toString')) {
             return $value->__toString();
         }


### PR DESCRIPTION
This PR currently allows for two things:
- Adds a stringify filter to twig so you can convert any variable to a string
- Adds a new case to the `StringConverter` to handle enums differently. If the value is an enum, it will return its value (`enum->value`)