### PR TITLE
Improve link styling (Meta #99)

### DIFF
--- a/src/Resources/assets/styles/_tailwind.scss
+++ b/src/Resources/assets/styles/_tailwind.scss
@@ -36,13 +36,26 @@
         @apply text-base font-semibold text-neutral-500;
     }
 
+    .whatwedo-utility-content {
+        @extend .whatwedo-utility-paragraph;
+
+        a {
+            text-decoration: underline solid currentColor;
+            text-underline-offset: 0.2em;
+            text-decoration-thickness: 1px;
+
+            &:hover {
+                @apply text-neutral-900;
+            }
+        }
+    }
+
     .whatwedo-utility-link {
         @extend .whatwedo-utility-heading-4;
-        @apply text-primary-500;
         text-decoration: underline solid transparent;
         text-underline-offset: 0.2em;
-        text-decoration-thickness: 2px;
-        transition: text-decoration 1s ease;
+        text-decoration-thickness: 1px;
+        transition: text-decoration 0.2s ease;
 
         &:hover {
             text-decoration-color: currentColor;


### PR DESCRIPTION
Improve styling of links within content blocks and also on link helper.

This will be replaced in a better way later. Also I'm still using `.whatwedo-utility-XY` utility class to not make migration even hard later.

Styling can be customized with this snippet:
```
.whatwedo-utility-content a {
    @apply text-primary-500;

    &:hover {
        @apply text-primary-600;
    }
}
```